### PR TITLE
If specify icon isn't exist, return 0, avoid overflow the container.

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -81,10 +81,10 @@ export default {
       return `0 0 ${this.icon.width} ${this.icon.height}`
     },
     width: function () {
-      return this.icon.width / 112 * this.scale
+      return this.icon ? this.icon.width / 112 * this.scale : 0
     },
     height: function () {
-      return this.icon.height / 112  * this.scale
+      return this.icon ? this.icon.height / 112  * this.scale : 0
     },
     style: function () {
       if (this.scale === 1) {


### PR DESCRIPTION
When icon name isn't exist, it will overflow container.