### PR TITLE
add click event

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -8,7 +8,8 @@
     :width="width"
     :height="height"
     :viewBox="box"
-    :style="style">
+    :style="style"
+    @click="$emit('click')">
     <slot>
       <template v-if="icon && icon.paths">
         <path v-for="(path, i) in icon.paths" :key="`path-${i}`" v-bind="path"/>


### PR DESCRIPTION
Sometimes it is really needed to fire an event such as click. It is not very convenient to add listener to every particular icon.