### PR TITLE
fix(ARIA): correct spelling of `aria-labelledby` attribute

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -204,7 +204,7 @@ export default {
 
     let titleId = `vat-${this.id}`
     if (this.title) {
-      options.attrs['aria-labelled-by'] = titleId
+      options.attrs['aria-labelledby'] = titleId
     }
 
     if (this.raw) {


### PR DESCRIPTION
Corrects `aria-labelled-by` to be `aria-labelledby`