### PR TITLE
Fix Rendering issue with Nuxt SSR

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -181,7 +181,7 @@ export default {
     }
   },
   render (h) {
-    if (this.name === null) {
+    if (!this.icon) {
       return h()
     }
 


### PR DESCRIPTION
Using Nuxt, I see the following error every now and then when I restart the Nuxt process.

ERROR  Cannot read property 'paths' of undefined

Changing the render check to check this.icon instead of this.name seems to fix the problem.